### PR TITLE
LLM-Coder[bot]: playground/server/main.py の read_root をHello Japan に変えて

### DIFF
--- a/playground/server/main.py
+++ b/playground/server/main.py
@@ -14,7 +14,7 @@ class Item(BaseModel):
 
 @app.get("/")
 def read_root():
-    return "Hello USA"
+    return "Hello Japan"
 
 
 @app.get("/items/{item_id}")


### PR DESCRIPTION
# Summary of Changes

**Main Change:**  
- Updated the root endpoint (`"/"`) to now return `"Hello Japan"` instead of `"Hello USA"`.

**Purpose:**  
- The modification personalizes or localizes the greeting message for the root URL, reflecting a change in the application's output to better align with the intended audience or context.

---
*Created by LLM Coder based on [Issue #2](https://github.com/igtm/llm_coder/issues/2).*
*Triggered by [comment](https://github.com/igtm/llm_coder/issues/2#issuecomment-2869365588).*