### PR TITLE
LLM-Coder[bot]: playground/server/main.py の read_root をHello Japan に変えて

### DIFF
--- a/playground/server/main.py
+++ b/playground/server/main.py
@@ -14,7 +14,7 @@ class Item(BaseModel):
 
 @app.get("/")
 def read_root():
-    return "Hello USA"
+    return "Hello Japan"
 
 
 @app.get("/items/{item_id}")


### PR DESCRIPTION
# Pull Request: ルートエンドポイントのレスポンスを変更

## 概要
`playground/server/main.py` のルート (`/`) REストレスポンスを `"Hello USA"` から `"Hello Japan"` に変更しました。

## 変更点
- `read_root()` 関数の返り値を `"Hello USA"` から `"Hello Japan"` に修正

## 目的
サーバーの挨拶メッセージを日本向けにローカライズするためです。

```
-  return "Hello USA"
+  return "Hello Japan"
```

---
*Created by LLM Coder based on [Issue #2](https://github.com/igtm/llm_coder/issues/2).*
*Triggered by [comment](https://github.com/igtm/llm_coder/issues/2#issuecomment-2869374105).*