### PR TITLE
LLM-Coder[bot]: playground/server/main.py の read_root をHello Japan に変えて

### DIFF
--- a/playground/server/main.py
+++ b/playground/server/main.py
@@ -14,7 +14,7 @@ class Item(BaseModel):
 
 @app.get("/")
 def read_root():
-    return "Hello USA"
+    return "Hello Japan"
 
 
 @app.get("/items/{item_id}")


### PR DESCRIPTION
# プルリクエスト概要

このPRでは、APIのルートエンドポイントのレスポンス内容を変更しました。

## 主な変更点
- ルートエンドポイント(`/`)のレスポンス文字列が、「Hello USA」から「Hello Japan」に更新されました。

## 目的
地域に関連した挨拶の内容をローカライズするための変更です。サーバーの基本的な応答メッセージを日本向けに調整しています。

---
*Created by LLM Coder based on [Issue #2](https://github.com/igtm/llm_coder/issues/2).*
*Triggered by [comment](https://github.com/igtm/llm_coder/issues/2#issuecomment-2869387200).*