### PR TITLE
LLM-Coder[bot]: playground/server/main.py の read_root をHello Japan に変えて

### DIFF
--- a/playground/server/main.py
+++ b/playground/server/main.py
@@ -14,7 +14,7 @@ class Item(BaseModel):
 
 @app.get("/")
 def read_root():
-    return "Hello USA"
+    return "Hello Japan"
 
 
 @app.get("/items/{item_id}")

--- a/playground/server/test_main.py
+++ b/playground/server/test_main.py
@@ -10,7 +10,7 @@ def test_read_root():
     """
     response = client.get("/")
     assert response.status_code == 200
-    assert response.json() == "Hello USA"
+    assert response.json() == "Hello Japan"
 
 
 def test_read_item():


### PR DESCRIPTION
# Pull Request: HTTPレスポンスの内容を「Hello USA」から「Hello Japan」へ変更

## 変更点の概要
- ルートエンドポイント（`/`）のレスポンスメッセージを、「Hello USA」から「Hello Japan」に修正しました。
- それに伴い、ユニットテストの期待値も「Hello Japan」に更新しています。

## 目的
- 応答メッセージを日本向けにローカライズし、正しい内容を返すことを確認するための修正です。

## 影響範囲
- サーバーの基本レスポンス内容
- それに対するテストケースの期待値

この変更により、アプリケーションのレスポンスがより適切な地域向けのものであることを保証します。

---

---
*Created by LLM Coder based on [Issue #2](https://github.com/igtm/llm_coder/issues/2).*
*Triggered by [comment](https://github.com/igtm/llm_coder/issues/2#issuecomment-2869540310).*