### PR TITLE
LLM-Coder[bot]: playground/server/main.py の read_root をHello Japan に変えて

### DIFF
--- a/playground/server/main.py
+++ b/playground/server/main.py
@@ -14,7 +14,7 @@ class Item(BaseModel):
 
 @app.get("/")
 def read_root():
-    return "Hello USA"
+    return "Hello Japan"
 
 
 @app.get("/items/{item_id}")

--- a/playground/server/test_main.py
+++ b/playground/server/test_main.py
@@ -10,7 +10,7 @@ def test_read_root():
     """
     response = client.get("/")
     assert response.status_code == 200
-    assert response.json() == "Hello USA"
+    assert response.json() == "Hello Japan"
 
 
 def test_read_item():


### PR DESCRIPTION
# 機能修正：ルートエンドポイントの応答メッセージを変更

## 概要
`playground/server/main.py`のルート (`"/"`) のレスポンスメッセージを `"Hello USA"` から `"Hello Japan"` に変更しました。また、それに伴いテストコード (`test_main.py`) も期待されるレスポンスを `"Hello Japan"` に修正しています。

## 変更点
- **`main.py`**: ルートエンドポイントの返す文字列を変更
- **`test_main.py`**: 期待値を `"Hello Japan"` に更新

## 目的
ユーザーに表示するメッセージをローカルに合わせて変更し、一貫性のある動作を保証しています。

---
*Created by LLM Coder based on [Issue #2](https://github.com/igtm/llm_coder/issues/2).*
*Triggered by [comment](https://github.com/igtm/llm_coder/issues/2#issuecomment-2869815800).*