### PR TITLE
LLM-Coder[bot]: playground/server/main.py の read_root をHello Japan に変えて

### DIFF
--- a/playground/server/main.py
+++ b/playground/server/main.py
@@ -14,7 +14,7 @@ class Item(BaseModel):
 
 @app.get("/")
 def read_root():
-    return "Hello USA"
+    return "Hello Japan"
 
 
 @app.get("/items/{item_id}")

--- a/playground/server/test_main.py
+++ b/playground/server/test_main.py
@@ -10,7 +10,7 @@ def test_read_root():
     """
     response = client.get("/")
     assert response.status_code == 200
-    assert response.json() == "Hello USA"
+    assert response.json() == "Hello Japan"
 
 
 def test_read_item():


### PR DESCRIPTION
# Pull Request の概要

このプルリクエストでは、サーバーのルートエンドポイントのレスポンス内容を変更しました。

## 主な変更点
- `/`エンドポイントのレスポンスメッセージを `"Hello USA"` から `"Hello Japan"` に修正しました。
- それに伴い、テストケースも期待されるレスポンスを `"Hello Japan"` に更新しました。

## 目的
この変更は、アプリケーションのレスポンス文言を日本向けに調整し、国際化対応の一環として行いました。

---
*Created by LLM Coder based on [Issue #2](https://github.com/igtm/llm_coder/issues/2).*
*Triggered by [comment](https://github.com/igtm/llm_coder/issues/2#issuecomment-2869869013).*